### PR TITLE
Support typescript textobjects

### DIFF
--- a/queries/typescript/iswap-list.scm
+++ b/queries/typescript/iswap-list.scm
@@ -1,0 +1,5 @@
+[
+  (arguments)
+  (array)
+  (formal_parameters)
+] @iswap-list


### PR DESCRIPTION
I've used the same treesitter text objects as javascript. It can be extended if needed.