### PR TITLE
feat: add dart query

### DIFF
--- a/queries/dart/iswap-list.scm
+++ b/queries/dart/iswap-list.scm
@@ -1,0 +1,7 @@
+[
+  (list_literal)
+  (type_arguments)
+  (type_parameters)
+  (arguments)
+  (formal_parameter_list)
+] @iswap-list


### PR DESCRIPTION
Hi 👋🏾 ,

This PR adds support for dart.
There are some quirks to it but I think that's based on how the grammar is structured and maybe not this plugin e.g.

![image](https://user-images.githubusercontent.com/22454918/120719433-25b12d00-c4c2-11eb-848f-5748446318e2.png)
Looking at the treesitter tree it looks like it's because an `item.prop` gives two *sibling* nodes `identifier` and `selector` and maybe the plugin doesn't expect sibling nodes to be anything other than parameters (swappable things). This works well enough generally apart from those cases.