### PR TITLE
add obj of query for typescript

### DIFF
--- a/queries/typescript/iswap-list.scm
+++ b/queries/typescript/iswap-list.scm
@@ -4,4 +4,7 @@
   (array_pattern)
   (formal_parameters)
   (named_imports)
+  (object)
+  (object_type)
+  (object_pattern)
 ] @iswap-list


### PR DESCRIPTION
You can test under below code.
```typescript
function toHexColor(color): { red: number; green: number; blue: number } {
	let { red, green, blue } = color
	return {
		red: Math.round(red * 255),
		green: Math.round(green * 255),
		blue: Math.round(blue * 255),
	}
}
```