### PR TITLE
Fix nil winid

### DIFF
--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -87,7 +87,7 @@ function M.iswap_with(config)
   -- nothing to swap here
   if #children < 2 then return end
 
-  local cur_nodes = util.nodes_containing_cursor(children)
+  local cur_nodes = util.nodes_containing_cursor(children, winid)
   if #cur_nodes == 0 then
     err('not on a node!', 1)
   end

--- a/lua/iswap/util.lua
+++ b/lua/iswap/util.lua
@@ -18,7 +18,7 @@ function M.within(a, b, c)
   return M.compare_position(a, b) and M.compare_position(b, c)
 end
 
-function M.nodes_containing_cursor(node)
+function M.nodes_containing_cursor(node, winid)
   local cursor = vim.api.nvim_win_get_cursor(winid)
   local cursor_range = { cursor[1] - 1, cursor[2] }
   return M.nodes_containing_pos(node, cursor_range)


### PR DESCRIPTION
Since neovim/neovim#16745, passing a `nil` value into API functions produces an error. This PR makes it so that `winid` (which as far as I can tell was always `nil` in the current code) is defined, preventing the error. 