### PR TITLE
add priority argument to `vim.highlight.range()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ require('iswap').setup{
   -- default 'Comment'
   hl_grey = 'LineNr',
 
+  -- Highlight priority for the greyed background
+  -- default '1000'
+  hl_grey_priority = '200',
+
   -- Automatically swap with only two arguments
   -- default nil
   autoswap = true

--- a/lua/iswap/defaults.lua
+++ b/lua/iswap/defaults.lua
@@ -4,6 +4,7 @@ M.keys = 'asdfghjklqwertyuiopzxcvbnm'
 M.hl_grey = 'Comment'
 M.hl_snipe = 'Search'
 M.hl_selection = 'Visual'
+M.hl_grey_priority = 1000
 M.grey = 'enable'
 
 return M

--- a/lua/iswap/ui.lua
+++ b/lua/iswap/ui.lua
@@ -17,8 +17,8 @@ function M.grey_the_rest_out(bufnr, config, begin_exclude, end_exclude)
   local top_line = win_info.topline - 1
   local bot_line = win_info.botline - 1
   M.clear_namespace(bufnr)
-  vim.highlight.range(bufnr, M.argts_ns, config.hl_grey, {top_line, 0}, begin_exclude)
-  vim.highlight.range(bufnr, M.argts_ns, config.hl_grey, end_exclude, {bot_line, -1})
+  vim.highlight.range(bufnr, M.argts_ns, config.hl_grey, {top_line, 0}, begin_exclude, 'v', false, config.hl_grey_priority)
+  vim.highlight.range(bufnr, M.argts_ns, config.hl_grey, end_exclude, {bot_line, -1}, 'v', false, config.hl_grey_priority)
 end
 
 -- Prompt user from NODES a total of TIMES times in BUFNR. CONFIG is used for


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/16963 adds a priority argument to `vim.highlight` functions. This makes hl_grey not work on syntax highlighted regions.

This PR should not break users of older neovim because the other added arguments were the default ones