### PR TITLE
Swap any node

### DIFF
--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -160,30 +160,35 @@ function M.iswap_node(config, direction)
 
 	-- pick parent recursive for current line
 	local ascendants = {cur_node}
+	local prev_parent = cur_node
 	local current_row = parent:start()
 	local last_row, last_col
 	while parent and parent:start() == current_row do -- only get parents - for current line
-		last_row, last_col = ascendants[#ascendants]:start()
+		last_row, last_col = prev_parent:start()
 		local s_row, s_col = parent:start()
 		if last_row == s_row and last_col == s_col then -- new parent has same start as last one. Override last one
-			ascendants[#ascendants] = parent
+			-- ignore  no sibling or  comment nodes
+			if not (parent:next_named_sibling() == nil and parent:prev_named_sibling() == nil) and parent:type() ~= "comment" then
+				ascendants[#ascendants] = parent
+			end
 		else
 			table.insert(ascendants, parent)
 			last_row = s_row
 			last_col = s_col
 		end
+		prev_parent = parent
 		parent = parent:parent()
 	end
 
 	-- remove ascendant node tha has no siblings
-	for i = #ascendants, 1, -1 do
-		local ascendant = ascendants[i]
-		if ascendant:type() == "comment" then
-			table.remove(ascendants, i)
-		elseif ascendant:next_named_sibling() == nil and ascendant:prev_named_sibling() == nil then
-			table.remove(ascendants, i)
-		end
-	end
+	-- for i = #ascendants, 1, -1 do
+	-- 	local ascendant = ascendants[i]
+	-- 	if ascendant:type() == "comment" then
+	-- 		table.remove(ascendants, i)
+	-- 	elseif ascendant:next_named_sibling() == nil and ascendant:prev_named_sibling() == nil then
+	-- 		table.remove(ascendants, i)
+	-- 	end
+	-- end
 
 	if #ascendants == 0 then
 		err('No proper node with siblings found to swap', config.debug)

--- a/lua/iswap/ui.lua
+++ b/lua/iswap/ui.lua
@@ -42,7 +42,7 @@ function M.prompt(bufnr, config, nodes, active_range, times)
   for i, node in ipairs(nodes) do
     local key = keys:sub(i, i)
     map[key] = node
-    ts_utils.highlight_node(node, bufnr, M.argts_ns, config.hl_selection)
+    -- ts_utils.highlight_node(node, bufnr, M.argts_ns, config.hl_selection) -- cant see anything with it
     local start_row, start_col = node:range()
     vim.api.nvim_buf_set_extmark(bufnr, M.argts_ns, start_row, start_col,
       { virt_text = { { key, config.hl_snipe } }, virt_text_pos = "overlay", hl_mode = "blend" })

--- a/lua/iswap/ui.lua
+++ b/lua/iswap/ui.lua
@@ -42,7 +42,7 @@ function M.prompt(bufnr, config, nodes, active_range, times)
   for i, node in ipairs(nodes) do
     local key = keys:sub(i, i)
     map[key] = node
-    -- ts_utils.highlight_node(node, bufnr, M.argts_ns, config.hl_selection) -- cant see anything with it
+    ts_utils.highlight_node(node, bufnr, M.argts_ns, config.hl_selection)
     local start_row, start_col = node:range()
     vim.api.nvim_buf_set_extmark(bufnr, M.argts_ns, start_row, start_col,
       { virt_text = { { key, config.hl_snipe } }, virt_text_pos = "overlay", hl_mode = "blend" })

--- a/plugin/iswap.vim
+++ b/plugin/iswap.vim
@@ -6,10 +6,18 @@ lua require("iswap").init()
 
 command ISwap lua require('iswap').iswap()
 command ISwapWith lua require('iswap').iswap_with()
-command ISwapNode lua require('iswap').iswap_node() " 1. pick cursor node any parent X, 2. swap picked ancestr X with its sibling
-command ISwapCursorNode lua require('iswap').iswap_cursor_node() " 1. Use cursor outer node X, 2. swap X with chosen siblings
-command ISwapCursorNodeRight lua require('iswap').iswap_cursor_node(nil, 'right') " Same as ISwapCursorNode but swap with right siblings
-command ISwapCursorNodeLeft lua require('iswap').iswap_cursor_node(nil, 'left')  " Same as ISwapCursorNode but swap with left siblings
+
+" 1. pick cursor node any parent X, 2. swap picked ancestr X with its sibling
+command ISwapNode lua require('iswap').iswap_node()
+
+" 1. Use cursor outer node X, 2. swap X with chosen siblings
+command ISwapCursorNode lua require('iswap').iswap_cursor_node()
+
+" Same as ISwapCursorNode but swap with right siblings
+command ISwapCursorNodeRight lua require('iswap').iswap_cursor_node(nil, 'right')
+
+" Same as ISwapCursorNode but swap with left siblings
+command ISwapCursorNodeLeft lua require('iswap').iswap_cursor_node(nil, 'left')
 
 " <Plug>ISwap will delay because it become <Plug>ISwapWith prefix sequences.
 " Use <Plug>ISwapNormal instead

--- a/plugin/iswap.vim
+++ b/plugin/iswap.vim
@@ -5,8 +5,11 @@ lua require("iswap").init()
 " highlight default link ISwapGrey Comment
 
 command ISwap lua require('iswap').iswap()
-command ISwapNode lua require('iswap').iswap_node()
 command ISwapWith lua require('iswap').iswap_with()
+command ISwapNode lua require('iswap').iswap_node() " 1. pick cursor node any parent X, 2. swap picked ancestr X with its sibling
+command ISwapCursorNode lua require('iswap').iswap_cursor_node() " 1. Use cursor outer node X, 2. swap X with chosen siblings
+command ISwapCursorNodeRight lua require('iswap').iswap_cursor_node(nil, 'right') " Same as ISwapCursorNode but swap with right siblings
+command ISwapCursorNodeLeft lua require('iswap').iswap_cursor_node(nil, 'left')  " Same as ISwapCursorNode but swap with left siblings
 
 " <Plug>ISwap will delay because it become <Plug>ISwapWith prefix sequences.
 " Use <Plug>ISwapNormal instead

--- a/plugin/iswap.vim
+++ b/plugin/iswap.vim
@@ -5,6 +5,7 @@ lua require("iswap").init()
 " highlight default link ISwapGrey Comment
 
 command ISwap lua require('iswap').iswap()
+command ISwapNode lua require('iswap').iswap_node()
 command ISwapWith lua require('iswap').iswap_with()
 
 " <Plug>ISwap will delay because it become <Plug>ISwapWith prefix sequences.


### PR DESCRIPTION
Implements idea from https://github.com/mizlan/iswap.nvim/issues/45

This PR, allows to swap any Treesitter node  (to next, prev, or any sibling) - not just lists, dict etc..
While waiting for this PR to be merged  (not sure if dev is active), I thought I would share new swapping modes.

- ISwapNode - steps: 1. pick any parent X, of cursor node (limited to current line)     2. swap picked ancestor X with its sibling
- ISwapCursorNode - steps: 1. Use cursor  node X,       2. swap X with chosen siblings
- ISwapCursorNodeRight - Same as ISwapCursorNode but swap with right siblings
- ISwapCursorNodeLeft - Same as ISwapCursorNode but swap with left siblings

The most useful IMO are SwapRight and swap Left, which I use constantly :
```lua
vim.api.nvim_set_keymap('n', '<m-h>', "<cmd>ISwapCursorNodeLeft<CR>", {noremap = true, silent = true}) -- move cursor node right
vim.api.nvim_set_keymap('n', '<m-l>', "<cmd>ISwapCursorNodeRight<CR>", {noremap = true, silent = true}) -- move cursor node left
```

https://user-images.githubusercontent.com/13521338/165275115-88be2c92-74f4-4bd4-8786-eb90905851e6.mp4



