### PR TITLE
docs: fix README.md missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ require('iswap').setup{
 
   -- Automatically swap with only two arguments
   -- default nil
-  autoswap = true
+  autoswap = true,
 
   -- Other default options you probably should not change:
   debug = nil,


### PR DESCRIPTION
Added missing comma so anyone can just copy paste it in their configs.