### PR TITLE
Allow for `nil` config in `setup()`

### DIFF
--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -11,7 +11,7 @@ local M = {}
 M.config = default_config
 
 function M.setup(config)
-  config = config or nil
+  config = config or {}
   M.config = setmetatable(config, { __index = default_config })
 end
 

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -11,6 +11,7 @@ local M = {}
 M.config = default_config
 
 function M.setup(config)
+  config = config or nil
   M.config = setmetatable(config, { __index = default_config })
 end
 


### PR DESCRIPTION
So you can do `iswap.setup()` without it throwing an error