### PR TITLE
fix flash_style disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ require('iswap').setup{
   hl_grey = 'LineNr',
 
   -- Post-operation flashing highlight style,
-  -- either 'simultaneous' or 'sequential', or 'none' to disable
+  -- either 'simultaneous' or 'sequential', or false to disable
   -- default 'sequential'
-  flash_style = 'sequential',
+  flash_style = false,
 
   -- Highlight group for flashing highlight afterward
   -- default 'IncSearch'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ require('iswap').setup{
   hl_grey = 'LineNr',
 
   -- Post-operation flashing highlight style,
-  -- either 'simultaneous' or 'sequential', or nil to disable
+  -- either 'simultaneous' or 'sequential', or 'none' to disable
   -- default 'sequential'
   flash_style = 'sequential',
 

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -71,11 +71,7 @@ function M.iswap(config)
     internal.swap_nodes_and_return_new_ranges(a, b, bufnr, true)
   )
 
-  if config.flash_style == 'simultaneous' then
-    ui.flash_confirm_simul(bufnr, { a_range, b_range }, config)
-  elseif config.flash_style == 'sequential' then
-    ui.flash_confirm_sequential(bufnr, { a_range, b_range }, config)
-  end
+  ui.flash_confirm(bufnr, { a_range, b_range }, config)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
@@ -155,11 +151,7 @@ function M.iswap_node_with(direction, config)
     internal.swap_nodes_and_return_new_ranges(outer_cursor_node, swap_node, bufnr, true)
   )
 
-  if config.flash_style == 'simultaneous' then
-    ui.flash_confirm_simul(bufnr, { a_range, b_range }, config)
-  elseif config.flash_style == 'sequential' then
-    ui.flash_confirm_sequential(bufnr, { a_range, b_range }, config)
-  end
+  ui.flash_confirm(bufnr, { a_range, b_range }, config)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
@@ -261,11 +253,7 @@ function M.iswap_node(config, direction)
     internal.swap_nodes_and_return_new_ranges(picked_node, swap_node, bufnr, true)
   )
 
-  if config.flash_style == 'simultaneous' then
-    ui.flash_confirm_simul(bufnr, { a_range, b_range }, config)
-  elseif config.flash_style == 'sequential' then
-    ui.flash_confirm_sequential(bufnr, { a_range, b_range }, config)
-  end
+  ui.flash_confirm(bufnr, { a_range, b_range }, config)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
@@ -327,11 +315,7 @@ function M.iswap_with(config)
     internal.swap_nodes_and_return_new_ranges(a, cur_node, bufnr, true)
   )
 
-  if config.flash_style == 'simultaneous' then
-    ui.flash_confirm_simul(bufnr, { a_range, b_range }, config)
-  elseif config.flash_style == 'sequential' then
-    ui.flash_confirm_sequential(bufnr, { a_range, b_range }, config)
-  end
+  ui.flash_confirm(bufnr, { a_range, b_range }, config)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapWith", -1)]])
 end

--- a/lua/iswap/ui.lua
+++ b/lua/iswap/ui.lua
@@ -94,4 +94,12 @@ function M.flash_confirm_sequential(bufnr, ranges, config)
   helper(1)
 end
 
+function M.flash_confirm(bufnr, ranges, config)
+  if config.flash_style == 'simultaneous' then
+    M.flash_confirm_simul(bufnr, ranges, config)
+  elseif config.flash_style == 'sequential' then
+    M.flash_confirm_sequential(bufnr, ranges, config)
+  end
+end
+
 return M


### PR DESCRIPTION
Disabling the flashing is broken. Setting `flash_style = nil` can't work, that field won't be merged with the default configs later on. Setting it to `none` (or any non-nil value other than `simultaneous|sequential`) works as expected:
```lua
require('iswap').setup({flash_style = 'none'})
```
