### PR TITLE
add check if treesitter is installed

### DIFF
--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -8,17 +8,6 @@ local err = util.err
 
 local M = {}
 
-M.config = default_config
-
-function M.setup(config)
-  config = config or {}
-  M.config = setmetatable(config, { __index = default_config })
-end
-
-function M.evaluate_config(config)
-  return config and setmetatable(config, {__index = M.config}) or M.config
-end
-
 function M.init()
   require 'nvim-treesitter'.define_modules {
     iswap = {
@@ -28,6 +17,18 @@ function M.init()
       end
     }
   }
+end
+
+M.config = default_config
+
+function M.setup(config)
+  M.init()
+  config = config or {}
+  M.config = setmetatable(config, { __index = default_config })
+end
+
+function M.evaluate_config(config)
+  return config and setmetatable(config, {__index = M.config}) or M.config
 end
 
 function M.iswap(config)

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -16,7 +16,7 @@ function M.setup(config)
 end
 
 function M.evaluate_config(config)
-  return config and setmetatable(config, { __index = M.config }) or M.config
+  return config and setmetatable(config, {__index = M.config}) or M.config
 end
 
 function M.init()
@@ -54,7 +54,7 @@ function M.iswap(config)
   if config.autoswap and #children == 2 then
     a, b = unpack(children)
   else
-    local user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 2)
+    local user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 2)
     if not (type(user_input) == 'table' and #user_input == 2) then
       err('did not get two valid user inputs', config.debug)
       return
@@ -75,6 +75,7 @@ function M.iswap(config)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
+
 
 function M.iswap_node_with(direction, config)
   config = M.evaluate_config(config)
@@ -132,7 +133,7 @@ function M.iswap_node_with(direction, config)
         swap_node = swap_node:prev_named_sibling()
       end
     else
-      user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 1)
+      user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
       if not (type(user_input) == 'table' and #user_input == 1) then
         err('did not get two valid user inputs', config.debug)
         return
@@ -180,7 +181,7 @@ function M.iswap_node(config, direction)
     local s_row, s_col = parent:start()
 
     if last_row == s_row and last_col == s_col then
-      -- new parent has same start as last one. Override last one
+    -- new parent has same start as last one. Override last one
       if util.has_siblings(parent) and parent:type() ~= 'comment' then
         -- only add if it has >0 siblings and is not comment node
         -- (override previous since same start position)
@@ -204,8 +205,8 @@ function M.iswap_node(config, direction)
   end
 
   -- pick: {cursor_node +  any ancestors} for swapping
-  local dim_exclude_range = { { last_row, 0 }, { last_row, 120 } }
-  local user_input = ui.prompt(bufnr, config, ancestors, dim_exclude_range, 1) -- no dim when picking swap_node ?
+  local dim_exclude_range = {{last_row, 0}, {last_row, 120}}
+  local user_input = ui.prompt(bufnr, config, ancestors, dim_exclude_range , 1) -- no dim when picking swap_node ?
   if not (type(user_input) == 'table' and #user_input == 1) then
     err('did not get two valid user inputs', config.debug)
     return
@@ -235,7 +236,7 @@ function M.iswap_node(config, direction)
       swap_node = children[1]
     end
   else -- draw picker
-    user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 1)
+    user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
     if not (type(user_input) == 'table' and #user_input == 1) then
       err('did not get two valid user inputs', config.debug)
       return
@@ -256,6 +257,7 @@ function M.iswap_node(config, direction)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
+
 
 -- TODO: refactor iswap() and iswap_with()
 -- swap current with one other node
@@ -302,7 +304,7 @@ function M.iswap_with(direction, config)
       -- already shifted over, no need for +1
       a = children[cur_nodes[1]]
     else
-      local user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 1)
+      local user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
       if not (type(user_input) == 'table' and #user_input == 1) then
         err('did not get a valid user input', config.debug)
         return

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -327,4 +327,14 @@ function M.iswap_with(direction, config)
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapWith", -1)]])
 end
 
+local cmd = vim.api.nvim_create_user_command
+cmd("ISwap", function() require("iswap").iswap() end, {})
+cmd("ISwapWith", function() require("iswap").iswap_with() end, {})
+cmd("ISwapWithRight", function() require("iswap").iswap_with("right") end, {})
+cmd("ISwapWithLeft", function() require("iswap").iswap_with("left") end, {})
+cmd("ISwapNode", function() require("iswap").iswap_node() end, {})
+cmd("ISwapNodeWith", function() require("iswap").iswap_node_with() end, {})
+cmd("ISwapNodeWithRight", function() require("iswap").iswap_node_with("right") end, {})
+cmd("ISwapNodeWithLeft", function() require("iswap").iswap_node_with("left") end, {})
+
 return M

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -16,7 +16,7 @@ function M.setup(config)
 end
 
 function M.evaluate_config(config)
-  return config and setmetatable(config, {__index = M.config}) or M.config
+  return config and setmetatable(config, { __index = M.config }) or M.config
 end
 
 function M.init()
@@ -54,7 +54,7 @@ function M.iswap(config)
   if config.autoswap and #children == 2 then
     a, b = unpack(children)
   else
-    local user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 2)
+    local user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 2)
     if not (type(user_input) == 'table' and #user_input == 2) then
       err('did not get two valid user inputs', config.debug)
       return
@@ -75,7 +75,6 @@ function M.iswap(config)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
-
 
 function M.iswap_node_with(direction, config)
   config = M.evaluate_config(config)
@@ -133,7 +132,7 @@ function M.iswap_node_with(direction, config)
         swap_node = swap_node:prev_named_sibling()
       end
     else
-      user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
+      user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 1)
       if not (type(user_input) == 'table' and #user_input == 1) then
         err('did not get two valid user inputs', config.debug)
         return
@@ -181,7 +180,7 @@ function M.iswap_node(config, direction)
     local s_row, s_col = parent:start()
 
     if last_row == s_row and last_col == s_col then
-    -- new parent has same start as last one. Override last one
+      -- new parent has same start as last one. Override last one
       if util.has_siblings(parent) and parent:type() ~= 'comment' then
         -- only add if it has >0 siblings and is not comment node
         -- (override previous since same start position)
@@ -205,8 +204,8 @@ function M.iswap_node(config, direction)
   end
 
   -- pick: {cursor_node +  any ancestors} for swapping
-  local dim_exclude_range = {{last_row, 0}, {last_row, 120}}
-  local user_input = ui.prompt(bufnr, config, ancestors, dim_exclude_range , 1) -- no dim when picking swap_node ?
+  local dim_exclude_range = { { last_row, 0 }, { last_row, 120 } }
+  local user_input = ui.prompt(bufnr, config, ancestors, dim_exclude_range, 1) -- no dim when picking swap_node ?
   if not (type(user_input) == 'table' and #user_input == 1) then
     err('did not get two valid user inputs', config.debug)
     return
@@ -236,7 +235,7 @@ function M.iswap_node(config, direction)
       swap_node = children[1]
     end
   else -- draw picker
-    user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
+    user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 1)
     if not (type(user_input) == 'table' and #user_input == 1) then
       err('did not get two valid user inputs', config.debug)
       return
@@ -257,7 +256,6 @@ function M.iswap_node(config, direction)
 
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapNormal", -1)]])
 end
-
 
 -- TODO: refactor iswap() and iswap_with()
 -- swap current with one other node
@@ -304,7 +302,7 @@ function M.iswap_with(direction, config)
       -- already shifted over, no need for +1
       a = children[cur_nodes[1]]
     else
-      local user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
+      local user_input = ui.prompt(bufnr, config, children, { { sr, sc }, { er, ec } }, 1)
       if not (type(user_input) == 'table' and #user_input == 1) then
         err('did not get a valid user input', config.debug)
         return

--- a/plugin/iswap.vim
+++ b/plugin/iswap.vim
@@ -1,5 +1,3 @@
-lua require("iswap").init()
-
 " Use the setup() function instead
 " highlight default link ISwapSnipe Search
 " highlight default link ISwapGrey Comment

--- a/plugin/iswap.vim
+++ b/plugin/iswap.vim
@@ -4,15 +4,6 @@ lua require("iswap").init()
 " highlight default link ISwapSnipe Search
 " highlight default link ISwapGrey Comment
 
-command ISwap lua require('iswap').iswap()
-command ISwapWith lua require('iswap').iswap_with()
-command ISwapWithRight lua require('iswap').iswap_with('right')
-command ISwapWithLeft lua require('iswap').iswap_with('left')
-command ISwapNode lua require('iswap').iswap_node()
-command ISwapNodeWith lua require('iswap').iswap_node_with()
-command ISwapNodeWithRight lua require('iswap').iswap_node_with('right')
-command ISwapNodeWithLeft lua require('iswap').iswap_node_with('left')
-
 " <Plug>ISwap will delay because it becomes <Plug>ISwapWith prefix sequence.
 " Use <Plug>ISwapNormal instead and etc for others
 nnoremap <Plug>ISwapNormal <Cmd>lua require('iswap').iswap()<CR>


### PR DESCRIPTION
This will silent out errors. It will be mostly true on first runs when pulling plugins with e.g., packer. 
Currently, iswap is one of the 3 out of 102 plugins in the config I use that screams loud at me during a first run. 
With this little guard it will be installed and keep calm.

As treesitter is a requirement I thought it might be a good practice to check for it.