### PR TITLE
improve swap left/right

### DIFF
--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -95,10 +95,10 @@ function M.iswap_node_with(direction, config)
     end
     if direction == 'right' and outer_cursor_node:next_named_sibling() ~= nil then -- only select node if it has a right sibling
       last_valid_node = outer_cursor_node
-		elseif direction == 'left' and outer_cursor_node:prev_named_sibling() ~= nil then  -- or left sibling
-			last_valid_node = outer_cursor_node
-		elseif direction == nil and util.has_siblings(outer_cursor_node) then  -- if no direction, then node with any sibling is ok
-			last_valid_node = outer_cursor_node
+    elseif direction == 'left' and outer_cursor_node:prev_named_sibling() ~= nil then  -- or left sibling
+      last_valid_node = outer_cursor_node
+    elseif direction == nil and util.has_siblings(outer_cursor_node) then  -- if no direction, then node with any sibling is ok
+        last_valid_node = outer_cursor_node
     end
     outer_cursor_node = outer_cursor_node:parent()
   end

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -93,8 +93,12 @@ function M.iswap_node_with(direction, config)
     if outer_row ~= current_row or outer_col ~= current_col then -- new outer parent to have same start()
       break
     end
-    if util.has_siblings(outer_cursor_node) then
+    if direction == 'right' and outer_cursor_node:next_named_sibling() ~= nil then -- only select node if it has a right sibling
       last_valid_node = outer_cursor_node
+		elseif direction == 'left' and outer_cursor_node:prev_named_sibling() ~= nil then  -- or left sibling
+			last_valid_node = outer_cursor_node
+		elseif direction == nil and util.has_siblings(outer_cursor_node) then  -- if no direction, then node with any sibling is ok
+			last_valid_node = outer_cursor_node
     end
     outer_cursor_node = outer_cursor_node:parent()
   end
@@ -133,7 +137,7 @@ function M.iswap_node_with(direction, config)
         swap_node = swap_node:prev_named_sibling()
       end
     else
-      user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
+      local user_input = ui.prompt(bufnr, config, children, {{sr, sc}, {er, ec}}, 1)
       if not (type(user_input) == 'table' and #user_input == 1) then
         err('did not get two valid user inputs', config.debug)
         return

--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -98,7 +98,7 @@ function M.iswap_node_with(direction, config)
     elseif direction == 'left' and outer_cursor_node:prev_named_sibling() ~= nil then  -- or left sibling
       last_valid_node = outer_cursor_node
     elseif direction == nil and util.has_siblings(outer_cursor_node) then  -- if no direction, then node with any sibling is ok
-        last_valid_node = outer_cursor_node
+      last_valid_node = outer_cursor_node
     end
     outer_cursor_node = outer_cursor_node:parent()
   end


### PR DESCRIPTION
When using node swap with direction, we want to be sure that we pick node that has 
- right sibling (when doing swap right)
- prev sibling (when swap left)
This PR takes above into account.  Node under cursor that has no correct sibling will be ignored. 