### PR TITLE
Add C and TypeScript enum queries

### DIFF
--- a/queries/c/iswap-list.scm
+++ b/queries/c/iswap-list.scm
@@ -1,5 +1,6 @@
 [
   (argument_list)
+  (enumerator_list)
   (initializer_list)
   (parameter_list)
 ] @iswap-list

--- a/queries/typescript/iswap-list.scm
+++ b/queries/typescript/iswap-list.scm
@@ -2,6 +2,7 @@
   (arguments)
   (array)
   (array_pattern)
+  (enum_body)
   (formal_parameters)
   (named_imports)
   (object)


### PR DESCRIPTION
Tiny PR to add support for enums, which are currently supported in some other languages, to C and TypeScript. 