### PR TITLE
wrapper functions which can be used to define count prefixed, dot repeatable keymaps

### DIFF
--- a/lua/iswap.lua
+++ b/lua/iswap.lua
@@ -331,4 +331,30 @@ function M.iswap_with(direction, config)
   vim.cmd([[silent! call repeat#set("\<Plug>ISwapWith", -1)]])
 end
 
+-- The following are convenience wrapper functions which can be used in dot
+-- repeatable keymaps. Keymaps are also capable to be prefixed with [count]
+function M.iswap_with_left()
+  for _ = 1, vim.v.count1 do
+    require('iswap').iswap_with('left')
+  end
+end
+
+function M.iswap_with_right()
+  for _ = 1, vim.v.count1 do
+    require('iswap').iswap_with('right')
+  end
+end
+
+function M.iswap_node_with_left()
+  for _ = 1, vim.v.count1 do
+    require('iswap').iswap_node_with('left')
+  end
+end
+
+function M.iswap_node_with_right()
+  for _ = 1, vim.v.count1 do
+    require('iswap').iswap_node_with('right')
+  end
+end
+
 return M


### PR DESCRIPTION
The added wrapper functions can be used in keymaps like following:

```lua
vim.keymap.set(
    'n',
    '[s',
    function ()
        vim.go.operatorfunc = "v:lua.require'iswap'.iswap_node_with_left"
        return 'g@l'
    end,
    { desc = 'Swap with [count] left node', expr = true }
)

vim.keymap.set(
    'n',
    ']s',
    function ()
        vim.go.operatorfunc = "v:lua.require'iswap'.iswap_node_with_right"
        return 'g@l'
    end,
    { desc = 'Swap with [count] right node', expr = true }
)
```

The resulting keymaps are dot repeatable and can be prefixed with [count]. 
Examples: `2[s`, `]s`

closes #68 