### PR TITLE
fix: rename ts_utils.get_node_range -> vim.treesitter.get_node_range

### DIFF
--- a/lua/iswap/internal.lua
+++ b/lua/iswap/internal.lua
@@ -62,7 +62,7 @@ local function private_ts_utils_get_node_text(node, bufnr)
   end
 
   -- We have to remember that end_col is end-exclusive
-  local start_row, start_col, end_row, end_col = ts_utils.get_node_range(node)
+  local start_row, start_col, end_row, end_col = vim.treesitter.get_node_range(node)
 
   if start_row ~= end_row then
     local lines = vim.api.nvim_buf_get_lines(bufnr, start_row, end_row + 1, false)


### PR DESCRIPTION
fix: https://github.com/nvim-treesitter/nvim-treesitter/pull/4300