### PR TITLE
fix(fennel): update queries

### DIFF
--- a/queries/fennel/iswap-list.scm
+++ b/queries/fennel/iswap-list.scm
@@ -1,5 +1,3 @@
-[
-  (list)
-  (table)
-  (sequence)
-] @iswap-list
+(_
+  open: ["(" "[" "{"]
+  close: [")" "]" "}"]) @iswap-list


### PR DESCRIPTION
Updated queries to support updated upstream parser.

This commit also simplifies and future-proofs the queries to support any `()`, `[]` and `{}` containers. Since everything in Lisp is a list, this should always work, unless the parser produces an incorrect parse tree, in which case it's a parser bug.