### PR TITLE
fix(elixir): remove bare_arguments from query

### DIFF
--- a/queries/elixir/iswap-list.scm
+++ b/queries/elixir/iswap-list.scm
@@ -3,7 +3,6 @@
   (list)
   (map)
   (tuple)
-  (bare_arguments)
   ; TODO: I wasn't able to figure out how to swap keyword
   ;       lists and maps with atom keys.
 ] @iswap-list


### PR DESCRIPTION
Fixes the following stacktrace that happens with elixir:

```
Error executing Lua callback: /usr/share/nvim/runtime/lua/vim/treesitter/query.lua:252: Query error at 6:4. Invalid node type "bare_arguments":
  (bare_arguments)
   ^

stack traceback:
        [C]: in function '_ts_parse_query'
        /usr/share/nvim/runtime/lua/vim/treesitter/query.lua:252: in function 'fn'
        /usr/share/nvim/runtime/lua/vim/func/_memoize.lua:58: in function 'fn'
        /usr/share/nvim/runtime/lua/vim/func/_memoize.lua:58: in function 'get_query'
        ...k/deps/opt/nvim-treesitter/lua/nvim-treesitter/query.lua:108: in function 'get_query'
        ...vim/site/pack/deps/opt/iswap.nvim/lua/iswap/internal.lua:24: in function 'find'
        ...vim/site/pack/deps/opt/iswap.nvim/lua/iswap/internal.lua:43: in function 'get_list_node_at_cursor'
        .../nvim/site/pack/deps/opt/iswap.nvim/lua/iswap/choose.lua:12: in function 'two_nodes_from_list'
        ...l/share/nvim/site/pack/deps/opt/iswap.nvim/lua/iswap.lua:69: in function <...l/share/nvim/site/pack/deps/opt/iswap.nvim/lua/iswap.lua:65>
        ...l/share/nvim/site/pack/deps/opt/iswap.nvim/lua/iswap.lua:57: in function <...l/share/nvim/site/pack/deps/opt/iswap.nvim/lua/iswap.lua:57>
```

`bare_arguments` does not exist in the node-types definition: https://github.com/elixir-lang/tree-sitter-elixir/blob/c7ae8b77e2749826dcf23df6514f08fdd68c66a3/src/node-types.json